### PR TITLE
Always set Xbin to 1 for FVB

### DIFF
--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -1137,7 +1137,12 @@ asynStatus AndorCCD::setupAcquisition()
         driverName, functionName, binX, binY, minX+1, minX+sizeX, minY+1, minY+sizeY);
       checkStatus(SetImage(binX, binY, minX+1, minX+sizeX, minY+1, minY+sizeY));
     }
-
+    if (readOutMode == ARFullVerticalBinning) {
+		  asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+			"%s:%s:, SetFVBHBin(%d)\n",
+			driverName, functionName, binX);
+		  checkStatus(SetFVBHBin(binX));
+    }
     asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
       "%s:%s:, SetExposureTime(%f)\n", 
       driverName, functionName, mAcquireTime);

--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -1064,6 +1064,7 @@ asynStatus AndorCCD::setupAcquisition()
     // Set maximum binning but do not update parameter, this preserves ADBinY
     // when going back to Image readout mode.
     binY = maxSizeY;
+    binX = 1;
   }
   if (minX > (maxSizeX - binX)) {
     minX = maxSizeX - binX;
@@ -1137,12 +1138,7 @@ asynStatus AndorCCD::setupAcquisition()
         driverName, functionName, binX, binY, minX+1, minX+sizeX, minY+1, minY+sizeY);
       checkStatus(SetImage(binX, binY, minX+1, minX+sizeX, minY+1, minY+sizeY));
     }
-    if (readOutMode == ARFullVerticalBinning) {
-		  asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
-			"%s:%s:, SetFVBHBin(%d)\n",
-			driverName, functionName, binX);
-		  checkStatus(SetFVBHBin(binX));
-    }
+
     asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
       "%s:%s:, SetExposureTime(%f)\n", 
       driverName, functionName, mAcquireTime);


### PR DESCRIPTION
In FVB readout mode SetFVBHBin() does not seem to work for some models. Instead always force binX to 1.
Once back in Image mode, binX should reflect user set value again.